### PR TITLE
Simplify function argument naming

### DIFF
--- a/R/aggregation.R
+++ b/R/aggregation.R
@@ -4,7 +4,7 @@
 #' of observations for the specified weight column, grouped by the specified columns.
 #' Optionally, it can include all combinations of the grouping variables, even if some combinations
 #' do not exist in the data, setting the counts to zero for those combinations.
-#' Info on replicate weight standard errors: https://usa.ipums.org/usa/repwt.shtml
+#' Info on replicate weight standard errors: https://usa.ipums.org/usa/repweight.shtml
 #'
 #' @param data A data frame or a database connection object containing the data to be aggregated.
 #' @param weight A string specifying the name of the column containing the weights.
@@ -18,7 +18,7 @@
 #' @export
 crosstab_count <- function(
     data,
-    wt,
+    weight,
     group_by,
     every_combo = FALSE
 ) {
@@ -27,7 +27,7 @@ crosstab_count <- function(
   result <- data |>
     group_by(across(all_of(group_by))) |>
     summarize(
-      weighted_count = sum(!!sym(wt), na.rm = TRUE),
+      weighted_count = sum(!!sym(weight), na.rm = TRUE),
       count = n(),
       .groups = "drop"
     )
@@ -57,7 +57,7 @@ crosstab_count <- function(
 crosstab_mean <- function(
     data, 
     value, 
-    wt, 
+    weight, 
     group_by,
     every_combo = FALSE
 ) {
@@ -65,9 +65,9 @@ crosstab_mean <- function(
     group_by(!!!syms(group_by)) |>
     summarize(
       # Weighted sumproducts
-      weighted_sumprod = sum(!!sym(value) * !!sym(wt), na.rm = TRUE),
+      weighted_sumprod = sum(!!sym(value) * !!sym(weight), na.rm = TRUE),
       # Weighted counts
-      weighted_count = sum(!!sym(wt), na.rm = TRUE),
+      weighted_count = sum(!!sym(weight), na.rm = TRUE),
       count = n(),
       .groups = "drop"
     ) |>
@@ -101,7 +101,7 @@ crosstab_mean <- function(
 #' @export
 crosstab_percent <- function(
     data, 
-    wt, 
+    weight, 
     group_by, 
     percent_group_by,
     every_combo = FALSE
@@ -113,7 +113,7 @@ crosstab_percent <- function(
   result <- data |>
     group_by(!!!syms(group_by)) |>
     summarize(
-      weighted_count = sum(!!sym(wt), na.rm = TRUE),
+      weighted_count = sum(!!sym(weight), na.rm = TRUE),
       count = n(),
       .groups = "drop"
     )

--- a/R/aggregation.R
+++ b/R/aggregation.R
@@ -7,7 +7,7 @@
 #' Info on replicate weight standard errors: https://usa.ipums.org/usa/repweight.shtml
 #'
 #' @param data A data frame or a database connection object containing the data to be aggregated.
-#' @param weight A string specifying the name of the column containing the weights.
+#' @param wt_col A string specifying the name of the column containing the weights.
 #' @param group_by A character vector of column names to group by.
 #' @param every_combo Logical, whether to include all combinations of the grouping variables,
 #'   setting counts to zero for combinations not present in the data. Defaults to `FALSE`.
@@ -18,7 +18,7 @@
 #' @export
 crosstab_count <- function(
     data,
-    weight,
+    wt_col,
     group_by,
     every_combo = FALSE
 ) {
@@ -27,7 +27,7 @@ crosstab_count <- function(
   result <- data |>
     group_by(across(all_of(group_by))) |>
     summarize(
-      weighted_count = sum(!!sym(weight), na.rm = TRUE),
+      weighted_count = sum(!!sym(wt_col), na.rm = TRUE),
       count = n(),
       .groups = "drop"
     )
@@ -48,7 +48,7 @@ crosstab_count <- function(
 #'
 #' @param data A data frame or a database connection object containing the data to be aggregated.
 #' @param value A string specifying the name of the column containing the values to be averaged.
-#' @param weight A string specifying the name of the column containing the weights.
+#' @param wt_col A string specifying the name of the column containing the weights.
 #' @param group_by A character vector of column names to group by.
 #'
 #' @return A tibble or database connection object containing the group-by columns and weighted mean for each group.
@@ -57,7 +57,7 @@ crosstab_count <- function(
 crosstab_mean <- function(
     data, 
     value, 
-    weight, 
+    wt_col, 
     group_by,
     every_combo = FALSE
 ) {
@@ -65,9 +65,9 @@ crosstab_mean <- function(
     group_by(!!!syms(group_by)) |>
     summarize(
       # Weighted sumproducts
-      weighted_sumprod = sum(!!sym(value) * !!sym(weight), na.rm = TRUE),
+      weighted_sumprod = sum(!!sym(value) * !!sym(wt_col), na.rm = TRUE),
       # Weighted counts
-      weighted_count = sum(!!sym(weight), na.rm = TRUE),
+      weighted_count = sum(!!sym(wt_col), na.rm = TRUE),
       count = n(),
       .groups = "drop"
     ) |>
@@ -91,7 +91,7 @@ crosstab_mean <- function(
 #' This function calculates percentages of weighted counts within specified groups.
 #'
 #' @param data A data frame or a database connection object containing the data to be aggregated.
-#' @param weight A string specifying the name of the column containing the weights.
+#' @param wt_col A string specifying the name of the column containing the weights.
 #' @param group_by A character vector of column names to group by for the main counts.
 #' @param percent_group_by A character vector of column names to group by for the percentage calculation.
 #'   All elements of `percent_group_by` must be included in `group_by`.
@@ -101,7 +101,7 @@ crosstab_mean <- function(
 #' @export
 crosstab_percent <- function(
     data, 
-    weight, 
+    wt_col, 
     group_by, 
     percent_group_by,
     every_combo = FALSE
@@ -113,7 +113,7 @@ crosstab_percent <- function(
   result <- data |>
     group_by(!!!syms(group_by)) |>
     summarize(
-      weighted_count = sum(!!sym(weight), na.rm = TRUE),
+      weighted_count = sum(!!sym(wt_col), na.rm = TRUE),
       count = n(),
       .groups = "drop"
     )

--- a/R/standard-error.R
+++ b/R/standard-error.R
@@ -8,7 +8,7 @@
 #' @param data A tibble or data frame containing the data to be analyzed.
 #' @param f A function that produces new columns or summary statistics. 
 #'   The function `f` must have an argument named `weight` to specify the weight column.
-#' @param wt_col A string indicating the column name to be used as the main weight.
+#' @param weight A string indicating the column name to be used as the main weight.
 #'   Defaults to `"weight"`.
 #' @param repwt_cols A vector of strings indicating the names of replicate weight 
 #'   columns in `data`. Defaults to `paste0("repwt", 1:80)`.
@@ -23,7 +23,7 @@
 bootstrap_replicates <- function(
     data, 
     f, # function producing new columns for standard errors. Must have an argument that is called "weight"
-    wt_col = "weight", # string name of weight column in `data`
+    weight = "weight", # string name of weight column in `data`
     repwt_cols = paste0("repwt", 1:4), # Vector of strings of replicate weight columns in `data`
     id_cols, # columns that collectively uniquely identify the output observations
     ... # Any additional arguments needed for function f
@@ -34,11 +34,11 @@ bootstrap_replicates <- function(
   
   # Collect the result of the main estimate and sort by id_cols
   main_estimate <- if (is.extra_args) {
-    f(data, weight = wt_col, ...) |> 
+    f(data, weight = weight, ...) |> 
       collect() |> 
       arrange(across(all_of(id_cols)))
   } else {
-    f(data, weight = wt_col) |> 
+    f(data, weight = weight) |> 
       collect() |> 
       arrange(across(all_of(id_cols)))
   }
@@ -128,7 +128,7 @@ se_from_bootstrap <- function(
 #' @param data A tibble or data frame containing the data to be analyzed.
 #' @param f A function that produces new columns or summary statistics. 
 #'   The function `f` must have an argument named `weight` to specify the weight column.
-#' @param wt_col A string indicating the column name to be used as the main weight.
+#' @param weight A string indicating the column name to be used as the main weight.
 #'   Defaults to `"weight"`.
 #' @param repwt_cols A vector of strings indicating the names of replicate weight 
 #'   columns in `data`. Defaults to `paste0("repwt", 1:4)`.
@@ -143,7 +143,7 @@ se_from_bootstrap <- function(
 estimate_with_bootstrap_se <- function(
     data, 
     f,  # Function producing new columns for standard errors. Must have an argument named "weight"
-    wt_col = "weight",  # String name of weight column in `data`
+    weight = "weight",  # String name of weight column in `data`
     repwt_cols = paste0("repwt", 1:4),  # Vector of strings of replicate weight columns in `data`
     constant = 4/80,  # See https://usa.ipums.org/usa/repwt.shtml for more info
     se_cols,  # Vector of string column names to produce standard errors on
@@ -153,7 +153,7 @@ estimate_with_bootstrap_se <- function(
   bootstrap <- bootstrap_replicates(
     data = data,
     f = f,
-    wt_col = wt_col,
+    weight = weight,
     repwt_cols = repwt_cols,
     ...
   )

--- a/R/standard-error.R
+++ b/R/standard-error.R
@@ -2,13 +2,13 @@
 #'
 #' Calculates results of a target function `f()` using a specified weight column,
 #' and also calculates results by substituting each of the specified `repwt_cols` 
-#' for the `weight` argument within `f()`. This is useful for calculating replicate 
+#' for the `wt_col` argument within `f()`. This is useful for calculating replicate 
 #' estimates required for standard error computation using replicate weights.
 #'
 #' @param data A tibble or data frame containing the data to be analyzed.
 #' @param f A function that produces new columns or summary statistics. 
-#'   The function `f` must have an argument named `weight` to specify the weight column.
-#' @param weight A string indicating the column name to be used as the main weight.
+#'   The function `f` must have an argument named `wt_col` to specify the weight column.
+#' @param wt_col A string indicating the column name to be used as the main weight.
 #'   Defaults to `"weight"`.
 #' @param repwt_cols A vector of strings indicating the names of replicate weight 
 #'   columns in `data`. Defaults to `paste0("repwt", 1:80)`.
@@ -22,8 +22,8 @@
 #' }
 bootstrap_replicates <- function(
     data, 
-    f, # function producing new columns for standard errors. Must have an argument that is called "weight"
-    weight = "weight", # string name of weight column in `data`
+    f, # function producing new columns for standard errors. Must have an argument that is called "wt_col"
+    wt_col = "weight", # string name of weight column in `data`
     repwt_cols = paste0("repwt", 1:4), # Vector of strings of replicate weight columns in `data`
     id_cols, # columns that collectively uniquely identify the output observations
     ... # Any additional arguments needed for function f
@@ -34,11 +34,11 @@ bootstrap_replicates <- function(
   
   # Collect the result of the main estimate and sort by id_cols
   main_estimate <- if (is.extra_args) {
-    f(data, weight = weight, ...) |> 
+    f(data, wt_col = wt_col, ...) |> 
       collect() |> 
       arrange(across(all_of(id_cols)))
   } else {
-    f(data, weight = weight) |> 
+    f(data, wt_col = wt_col) |> 
       collect() |> 
       arrange(across(all_of(id_cols)))
   }
@@ -46,11 +46,11 @@ bootstrap_replicates <- function(
   # Apply function to replicate weights, collect, and sort by id_cols
   replicate_estimates <- map(repwt_cols, function(.x) {
     if (is.extra_args) {
-      f(data, weight = .x, ...) |> 
+      f(data, wt_col = .x, ...) |> 
         collect() |> 
         arrange(across(all_of(id_cols)))
     } else {
-      f(data, weight = .x) |> 
+      f(data, wt_col = .x) |> 
         collect() |> 
         arrange(across(all_of(id_cols)))
     }
@@ -122,13 +122,13 @@ se_from_bootstrap <- function(
 #' Combines bootstrap replicate estimation and standard error calculation into a single function.
 #' It calculates results of a target function `f()` using a specified weight column,
 #' computes replicate estimates by substituting each of the specified `repwt_cols` 
-#' for the `weight` argument within `f()`, and then calculates standard errors across 
+#' for the `wt_col` argument within `f()`, and then calculates standard errors across 
 #' specified columns using the output of `bootstrap_replicates()`.
 #'
 #' @param data A tibble or data frame containing the data to be analyzed.
 #' @param f A function that produces new columns or summary statistics. 
-#'   The function `f` must have an argument named `weight` to specify the weight column.
-#' @param weight A string indicating the column name to be used as the main weight.
+#'   The function `f` must have an argument named `wt_col` to specify the weight column.
+#' @param wt_col A string indicating the column name to be used as the main weight.
 #'   Defaults to `"weight"`.
 #' @param repwt_cols A vector of strings indicating the names of replicate weight 
 #'   columns in `data`. Defaults to `paste0("repwt", 1:4)`.
@@ -142,8 +142,8 @@ se_from_bootstrap <- function(
 #'   have the prefix `"se_"`.
 estimate_with_bootstrap_se <- function(
     data, 
-    f,  # Function producing new columns for standard errors. Must have an argument named "weight"
-    weight = "weight",  # String name of weight column in `data`
+    f,  # Function producing new columns for standard errors. Must have an argument named "wt_col"
+    wt_col = "weight",  # String name of weight column in `data`
     repwt_cols = paste0("repwt", 1:4),  # Vector of strings of replicate weight columns in `data`
     constant = 4/80,  # See https://usa.ipums.org/usa/repwt.shtml for more info
     se_cols,  # Vector of string column names to produce standard errors on
@@ -153,7 +153,7 @@ estimate_with_bootstrap_se <- function(
   bootstrap <- bootstrap_replicates(
     data = data,
     f = f,
-    weight = weight,
+    wt_col = wt_col,
     repwt_cols = repwt_cols,
     ...
   )

--- a/R/standard-error.R
+++ b/R/standard-error.R
@@ -2,14 +2,14 @@
 #'
 #' Calculates results of a target function `f()` using a specified weight column,
 #' and also calculates results by substituting each of the specified `repwt_cols` 
-#' for the `wt` argument within `f()`. This is useful for calculating replicate 
+#' for the `weight` argument within `f()`. This is useful for calculating replicate 
 #' estimates required for standard error computation using replicate weights.
 #'
 #' @param data A tibble or data frame containing the data to be analyzed.
 #' @param f A function that produces new columns or summary statistics. 
-#'   The function `f` must have an argument named `wt` to specify the weight column.
+#'   The function `f` must have an argument named `weight` to specify the weight column.
 #' @param wt_col A string indicating the column name to be used as the main weight.
-#'   Defaults to `"wt"`.
+#'   Defaults to `"weight"`.
 #' @param repwt_cols A vector of strings indicating the names of replicate weight 
 #'   columns in `data`. Defaults to `paste0("repwt", 1:80)`.
 #' @param ... Additional arguments passed to the function `f`.
@@ -22,8 +22,8 @@
 #' }
 bootstrap_replicates <- function(
     data, 
-    f, # function producing new columns for standard errors. Must have an argument that is called "wt"
-    wt_col = "wt", # string name of weight column in `data`
+    f, # function producing new columns for standard errors. Must have an argument that is called "weight"
+    wt_col = "weight", # string name of weight column in `data`
     repwt_cols = paste0("repwt", 1:4), # Vector of strings of replicate weight columns in `data`
     id_cols, # columns that collectively uniquely identify the output observations
     ... # Any additional arguments needed for function f
@@ -34,11 +34,11 @@ bootstrap_replicates <- function(
   
   # Collect the result of the main estimate and sort by id_cols
   main_estimate <- if (is.extra_args) {
-    f(data, wt = wt_col, ...) |> 
+    f(data, weight = wt_col, ...) |> 
       collect() |> 
       arrange(across(all_of(id_cols)))
   } else {
-    f(data, wt = wt_col) |> 
+    f(data, weight = wt_col) |> 
       collect() |> 
       arrange(across(all_of(id_cols)))
   }
@@ -46,11 +46,11 @@ bootstrap_replicates <- function(
   # Apply function to replicate weights, collect, and sort by id_cols
   replicate_estimates <- map(repwt_cols, function(.x) {
     if (is.extra_args) {
-      f(data, wt = .x, ...) |> 
+      f(data, weight = .x, ...) |> 
         collect() |> 
         arrange(across(all_of(id_cols)))
     } else {
-      f(data, wt = .x) |> 
+      f(data, weight = .x) |> 
         collect() |> 
         arrange(across(all_of(id_cols)))
     }
@@ -122,14 +122,14 @@ se_from_bootstrap <- function(
 #' Combines bootstrap replicate estimation and standard error calculation into a single function.
 #' It calculates results of a target function `f()` using a specified weight column,
 #' computes replicate estimates by substituting each of the specified `repwt_cols` 
-#' for the `wt` argument within `f()`, and then calculates standard errors across 
+#' for the `weight` argument within `f()`, and then calculates standard errors across 
 #' specified columns using the output of `bootstrap_replicates()`.
 #'
 #' @param data A tibble or data frame containing the data to be analyzed.
 #' @param f A function that produces new columns or summary statistics. 
-#'   The function `f` must have an argument named `wt` to specify the weight column.
+#'   The function `f` must have an argument named `weight` to specify the weight column.
 #' @param wt_col A string indicating the column name to be used as the main weight.
-#'   Defaults to `"wt"`.
+#'   Defaults to `"weight"`.
 #' @param repwt_cols A vector of strings indicating the names of replicate weight 
 #'   columns in `data`. Defaults to `paste0("repwt", 1:4)`.
 #' @param constant A constant used in the standard error calculation. For IPUMS data, 
@@ -142,8 +142,8 @@ se_from_bootstrap <- function(
 #'   have the prefix `"se_"`.
 estimate_with_bootstrap_se <- function(
     data, 
-    f,  # Function producing new columns for standard errors. Must have an argument named "wt"
-    wt_col = "wt",  # String name of weight column in `data`
+    f,  # Function producing new columns for standard errors. Must have an argument named "weight"
+    wt_col = "weight",  # String name of weight column in `data`
     repwt_cols = paste0("repwt", 1:4),  # Vector of strings of replicate weight columns in `data`
     constant = 4/80,  # See https://usa.ipums.org/usa/repwt.shtml for more info
     se_cols,  # Vector of string column names to produce standard errors on

--- a/README.md
+++ b/README.md
@@ -8,3 +8,59 @@ Tests are located in the `tests/testthat` folder. To run all tests:
 library("devtools")
 devtools::test()
 ```
+
+# Contribution Guidelines
+
+## Variable naming conventions
+**1. Data Variables**: In this R package, variables often refer to data that is either:
+
+  - Stored in R memory as a **tibble**.
+  - Stored on a DuckDB server as a **pointer to a database table**. 
+  
+These two data types are handled differently, and failing to distinguish between them may lead to subtle bugs. To prevent this:
+
+  - Variables referring to an **in-memory tibble** are suffixed with `_tb`.
+  - Variables referring to an **on-server database table** are suffixed with `_db`.
+  
+**Example:**
+
+``` r
+library(duckdb)
+library(dplyr)
+
+# The name of `iris` data represented as a tibble is `iris_tb`
+iris_tb <- tibble(iris)
+
+# The name of `iris` data represented as a pointer to a database table is `iris_db`. But the name of the table itself, in the connection, is just `iris`.
+con <- dbConnect(duckdb::duckdb(), ":memory:")
+dbWriteTable(con, "iris", iris_tb, overwrite = TRUE)
+iris_db <- tbl(con, "iris")
+dbDisconnect(con)
+```
+
+**2. Column name arguments**: Many functions have arguments that are strings representing column names in the data. To clearly indicate that an argument represents a column name, we suffix it with `_col`.
+
+**Example:**
+
+``` r
+library(dplyr)
+
+# Define the function
+calculate_group_average <- function(
+  data, 
+  group_col, 
+  value_col
+  ) {
+  data |>
+    group_by(.data[[group_col]]) |>
+    summarize(average = mean(.data[[value_col]], na.rm = TRUE)) |>
+    ungroup()
+}
+
+# Example usage
+calculate_group_average(
+  data = iris_tb,
+  group_col = "Species",
+  value_col = "Petal.Width"
+)
+```

--- a/man/bootstrap_replicates.Rd
+++ b/man/bootstrap_replicates.Rd
@@ -7,7 +7,7 @@
 bootstrap_replicates(
   data,
   f,
-  weight = "weight",
+  wt_col = "weight",
   repwt_cols = paste0("repwt", 1:4),
   id_cols,
   ...
@@ -17,9 +17,9 @@ bootstrap_replicates(
 \item{data}{A tibble or data frame containing the data to be analyzed.}
 
 \item{f}{A function that produces new columns or summary statistics.
-The function \code{f} must have an argument named \code{weight} to specify the weight column.}
+The function \code{f} must have an argument named \code{wt_col} to specify the weight column.}
 
-\item{weight}{A string indicating the column name to be used as the main weight.
+\item{wt_col}{A string indicating the column name to be used as the main weight.
 Defaults to \code{"weight"}.}
 
 \item{repwt_cols}{A vector of strings indicating the names of replicate weight
@@ -38,6 +38,6 @@ replicate weight column.}
 \description{
 Calculates results of a target function \code{f()} using a specified weight column,
 and also calculates results by substituting each of the specified \code{repwt_cols}
-for the \code{weight} argument within \code{f()}. This is useful for calculating replicate
+for the \code{wt_col} argument within \code{f()}. This is useful for calculating replicate
 estimates required for standard error computation using replicate weights.
 }

--- a/man/bootstrap_replicates.Rd
+++ b/man/bootstrap_replicates.Rd
@@ -7,7 +7,7 @@
 bootstrap_replicates(
   data,
   f,
-  wt_col = "wt",
+  weight = "weight",
   repwt_cols = paste0("repwt", 1:4),
   id_cols,
   ...
@@ -19,8 +19,8 @@ bootstrap_replicates(
 \item{f}{A function that produces new columns or summary statistics.
 The function \code{f} must have an argument named \code{weight} to specify the weight column.}
 
-\item{wt_col}{A string indicating the column name to be used as the main weight.
-Defaults to \code{"wt"}.}
+\item{weight}{A string indicating the column name to be used as the main weight.
+Defaults to \code{"weight"}.}
 
 \item{repwt_cols}{A vector of strings indicating the names of replicate weight
 columns in \code{data}. Defaults to \code{paste0("repwt", 1:80)}.}

--- a/man/bootstrap_replicates.Rd
+++ b/man/bootstrap_replicates.Rd
@@ -17,7 +17,7 @@ bootstrap_replicates(
 \item{data}{A tibble or data frame containing the data to be analyzed.}
 
 \item{f}{A function that produces new columns or summary statistics.
-The function \code{f} must have an argument named \code{wt} to specify the weight column.}
+The function \code{f} must have an argument named \code{weight} to specify the weight column.}
 
 \item{wt_col}{A string indicating the column name to be used as the main weight.
 Defaults to \code{"wt"}.}
@@ -38,6 +38,6 @@ replicate weight column.}
 \description{
 Calculates results of a target function \code{f()} using a specified weight column,
 and also calculates results by substituting each of the specified \code{repwt_cols}
-for the \code{wt} argument within \code{f()}. This is useful for calculating replicate
+for the \code{weight} argument within \code{f()}. This is useful for calculating replicate
 estimates required for standard error computation using replicate weights.
 }

--- a/man/crosstab_count.Rd
+++ b/man/crosstab_count.Rd
@@ -4,12 +4,12 @@
 \alias{crosstab_count}
 \title{Calculate Weighted and Unweighted Counts for Groups}
 \usage{
-crosstab_count(data, weight, group_by, every_combo = FALSE)
+crosstab_count(data, wt_col, group_by, every_combo = FALSE)
 }
 \arguments{
 \item{data}{A data frame or a database connection object containing the data to be aggregated.}
 
-\item{weight}{A string specifying the name of the column containing the weights.}
+\item{wt_col}{A string specifying the name of the column containing the weights.}
 
 \item{group_by}{A character vector of column names to group by.}
 

--- a/man/crosstab_count.Rd
+++ b/man/crosstab_count.Rd
@@ -4,17 +4,17 @@
 \alias{crosstab_count}
 \title{Calculate Weighted and Unweighted Counts for Groups}
 \usage{
-crosstab_count(data, wt, group_by, every_combo = FALSE)
+crosstab_count(data, weight, group_by, every_combo = FALSE)
 }
 \arguments{
 \item{data}{A data frame or a database connection object containing the data to be aggregated.}
+
+\item{weight}{A string specifying the name of the column containing the weights.}
 
 \item{group_by}{A character vector of column names to group by.}
 
 \item{every_combo}{Logical, whether to include all combinations of the grouping variables,
 setting counts to zero for combinations not present in the data. Defaults to \code{FALSE}.}
-
-\item{weight}{A string specifying the name of the column containing the weights.}
 }
 \value{
 A tibble or database connection object containing the group-by columns, weighted count,
@@ -25,5 +25,5 @@ This function calculates the weighted count (sum of weights) and the unweighted 
 of observations for the specified weight column, grouped by the specified columns.
 Optionally, it can include all combinations of the grouping variables, even if some combinations
 do not exist in the data, setting the counts to zero for those combinations.
-Info on replicate weight standard errors: https://usa.ipums.org/usa/repwt.shtml
+Info on replicate weight standard errors: https://usa.ipums.org/usa/repweight.shtml
 }

--- a/man/crosstab_mean.Rd
+++ b/man/crosstab_mean.Rd
@@ -4,14 +4,14 @@
 \alias{crosstab_mean}
 \title{Calculate Weighted Mean for Groups}
 \usage{
-crosstab_mean(data, value, weight, group_by, every_combo = FALSE)
+crosstab_mean(data, value, wt_col, group_by, every_combo = FALSE)
 }
 \arguments{
 \item{data}{A data frame or a database connection object containing the data to be aggregated.}
 
 \item{value}{A string specifying the name of the column containing the values to be averaged.}
 
-\item{weight}{A string specifying the name of the column containing the weights.}
+\item{wt_col}{A string specifying the name of the column containing the weights.}
 
 \item{group_by}{A character vector of column names to group by.}
 }

--- a/man/crosstab_mean.Rd
+++ b/man/crosstab_mean.Rd
@@ -4,16 +4,16 @@
 \alias{crosstab_mean}
 \title{Calculate Weighted Mean for Groups}
 \usage{
-crosstab_mean(data, value, wt, group_by, every_combo = FALSE)
+crosstab_mean(data, value, weight, group_by, every_combo = FALSE)
 }
 \arguments{
 \item{data}{A data frame or a database connection object containing the data to be aggregated.}
 
 \item{value}{A string specifying the name of the column containing the values to be averaged.}
 
-\item{group_by}{A character vector of column names to group by.}
-
 \item{weight}{A string specifying the name of the column containing the weights.}
+
+\item{group_by}{A character vector of column names to group by.}
 }
 \value{
 A tibble or database connection object containing the group-by columns and weighted mean for each group.

--- a/man/crosstab_percent.Rd
+++ b/man/crosstab_percent.Rd
@@ -4,12 +4,12 @@
 \alias{crosstab_percent}
 \title{Calculate Percentages Within Groups}
 \usage{
-crosstab_percent(data, weight, group_by, percent_group_by, every_combo = FALSE)
+crosstab_percent(data, wt_col, group_by, percent_group_by, every_combo = FALSE)
 }
 \arguments{
 \item{data}{A data frame or a database connection object containing the data to be aggregated.}
 
-\item{weight}{A string specifying the name of the column containing the weights.}
+\item{wt_col}{A string specifying the name of the column containing the weights.}
 
 \item{group_by}{A character vector of column names to group by for the main counts.}
 

--- a/man/crosstab_percent.Rd
+++ b/man/crosstab_percent.Rd
@@ -4,17 +4,17 @@
 \alias{crosstab_percent}
 \title{Calculate Percentages Within Groups}
 \usage{
-crosstab_percent(data, wt, group_by, percent_group_by, every_combo = FALSE)
+crosstab_percent(data, weight, group_by, percent_group_by, every_combo = FALSE)
 }
 \arguments{
 \item{data}{A data frame or a database connection object containing the data to be aggregated.}
+
+\item{weight}{A string specifying the name of the column containing the weights.}
 
 \item{group_by}{A character vector of column names to group by for the main counts.}
 
 \item{percent_group_by}{A character vector of column names to group by for the percentage calculation.
 All elements of \code{percent_group_by} must be included in \code{group_by}.}
-
-\item{weight}{A string specifying the name of the column containing the weights.}
 }
 \value{
 A tibble or database connection object containing the group-by columns and percentages for each group.

--- a/man/estimate_with_bootstrap_se.Rd
+++ b/man/estimate_with_bootstrap_se.Rd
@@ -18,10 +18,10 @@ estimate_with_bootstrap_se(
 \item{data}{A tibble or data frame containing the data to be analyzed.}
 
 \item{f}{A function that produces new columns or summary statistics.
-The function \code{f} must have an argument named \code{wt} to specify the weight column.}
+The function \code{f} must have an argument named \code{weight} to specify the weight column.}
 
 \item{wt_col}{A string indicating the column name to be used as the main weight.
-Defaults to \code{"wt"}.}
+Defaults to \code{"weight"}.}
 
 \item{repwt_cols}{A vector of strings indicating the names of replicate weight
 columns in \code{data}. Defaults to \code{paste0("repwt", 1:4)}.}
@@ -42,6 +42,6 @@ have the prefix \code{"se_"}.
 Combines bootstrap replicate estimation and standard error calculation into a single function.
 It calculates results of a target function \code{f()} using a specified weight column,
 computes replicate estimates by substituting each of the specified \code{repwt_cols}
-for the \code{wt} argument within \code{f()}, and then calculates standard errors across
+for the \code{weight} argument within \code{f()}, and then calculates standard errors across
 specified columns using the output of \code{bootstrap_replicates()}.
 }

--- a/man/estimate_with_bootstrap_se.Rd
+++ b/man/estimate_with_bootstrap_se.Rd
@@ -7,7 +7,7 @@
 estimate_with_bootstrap_se(
   data,
   f,
-  wt_col = "wt",
+  weight = "weight",
   repwt_cols = paste0("repwt", 1:4),
   constant = 4/80,
   se_cols,
@@ -20,7 +20,7 @@ estimate_with_bootstrap_se(
 \item{f}{A function that produces new columns or summary statistics.
 The function \code{f} must have an argument named \code{weight} to specify the weight column.}
 
-\item{wt_col}{A string indicating the column name to be used as the main weight.
+\item{weight}{A string indicating the column name to be used as the main weight.
 Defaults to \code{"weight"}.}
 
 \item{repwt_cols}{A vector of strings indicating the names of replicate weight

--- a/man/estimate_with_bootstrap_se.Rd
+++ b/man/estimate_with_bootstrap_se.Rd
@@ -7,7 +7,7 @@
 estimate_with_bootstrap_se(
   data,
   f,
-  weight = "weight",
+  wt_col = "weight",
   repwt_cols = paste0("repwt", 1:4),
   constant = 4/80,
   se_cols,
@@ -18,9 +18,9 @@ estimate_with_bootstrap_se(
 \item{data}{A tibble or data frame containing the data to be analyzed.}
 
 \item{f}{A function that produces new columns or summary statistics.
-The function \code{f} must have an argument named \code{weight} to specify the weight column.}
+The function \code{f} must have an argument named \code{wt_col} to specify the weight column.}
 
-\item{weight}{A string indicating the column name to be used as the main weight.
+\item{wt_col}{A string indicating the column name to be used as the main weight.
 Defaults to \code{"weight"}.}
 
 \item{repwt_cols}{A vector of strings indicating the names of replicate weight
@@ -42,6 +42,6 @@ have the prefix \code{"se_"}.
 Combines bootstrap replicate estimation and standard error calculation into a single function.
 It calculates results of a target function \code{f()} using a specified weight column,
 computes replicate estimates by substituting each of the specified \code{repwt_cols}
-for the \code{weight} argument within \code{f()}, and then calculates standard errors across
+for the \code{wt_col} argument within \code{f()}, and then calculates standard errors across
 specified columns using the output of \code{bootstrap_replicates()}.
 }

--- a/tests/testthat/test-bootstrap-replicates.R
+++ b/tests/testthat/test-bootstrap-replicates.R
@@ -15,7 +15,7 @@ input <- tibble(
   per_id = c(1, 2, 3, 4, 5),
   sex = c(1, 0, 1, 1, 0),
   hhsize = c(2, 3, 2, 1, 1),
-  wt = c(10, 12, 15, 30, 20),
+  weight = c(10, 12, 15, 30, 20),
   repwt1 = c(11, 13, 16, 28, 22),
   repwt2 = c(8, 8, 16, 25, 22),
   repwt3 = c(2, 4, 10, 14, 13),
@@ -25,13 +25,13 @@ input <- tibble(
 # Initialize two test functions to run using bootstrap_replicates
 hhsize_by_sex <- function(
     data,
-    wt, # string name of weight column in `data`
+    weight, # string name of weight column in `data`
     hhsize # string name of hhsize column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
-      weighted_mean = sum(.data[[hhsize]] * .data[[wt]], na.rm = TRUE)/sum(.data[[wt]], na.rm = TRUE),
+      weighted_mean = sum(.data[[hhsize]] * .data[[weight]], na.rm = TRUE)/sum(.data[[weight]], na.rm = TRUE),
       .groups = "drop"
     )
   
@@ -40,13 +40,13 @@ hhsize_by_sex <- function(
 
 count_by_sex <- function(
     data,
-    wt # string name of weight column in `data`
+    weight # string name of weight column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
       count = n(),
-      weighted_count = sum(.data[[wt]]),
+      weighted_count = sum(.data[[weight]]),
       .groups = "drop"
     )
   
@@ -57,7 +57,7 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   output_hhsize <- bootstrap_replicates(
     data = input,
     f = hhsize_by_sex,
-    wt_col = "wt",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     hhsize = "hhsize",
     id_cols = "sex"
@@ -66,23 +66,23 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   # Compare results
   expect_equal(
     output_hhsize$main_estimate, 
-    hhsize_by_sex(input, wt = "wt", hhsize = "hhsize")
+    hhsize_by_sex(input, weight = "weight", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[1]], 
-    hhsize_by_sex(input, wt = "repwt1", hhsize = "hhsize")
+    hhsize_by_sex(input, weight = "repwt1", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[2]], 
-    hhsize_by_sex(input, wt = "repwt2", hhsize = "hhsize")
+    hhsize_by_sex(input, weight = "repwt2", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[3]], 
-    hhsize_by_sex(input, wt = "repwt3", hhsize = "hhsize")
+    hhsize_by_sex(input, weight = "repwt3", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[4]], 
-    hhsize_by_sex(input, wt = "repwt4", hhsize = "hhsize")
+    hhsize_by_sex(input, weight = "repwt4", hhsize = "hhsize")
   )
 })
 
@@ -90,7 +90,7 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   output_count <- bootstrap_replicates(
     data = input,
     f = count_by_sex,
-    wt_col = "wt",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     id_cols = "sex"
   )
@@ -98,22 +98,22 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   # Compare results for count_by_sex
   expect_equal(
     output_count$main_estimate, 
-    count_by_sex(input, wt = "wt")
+    count_by_sex(input, weight = "weight")
   )
   expect_equal(
     output_count$replicate_estimates[[1]], 
-    count_by_sex(input, wt = "repwt1")
+    count_by_sex(input, weight = "repwt1")
   )
   expect_equal(
     output_count$replicate_estimates[[2]], 
-    count_by_sex(input, wt = "repwt2")
+    count_by_sex(input, weight = "repwt2")
   )
   expect_equal(
     output_count$replicate_estimates[[3]], 
-    count_by_sex(input, wt = "repwt3")
+    count_by_sex(input, weight = "repwt3")
   )
   expect_equal(
     output_count$replicate_estimates[[4]], 
-    count_by_sex(input, wt = "repwt4")
+    count_by_sex(input, weight = "repwt4")
   )
 })

--- a/tests/testthat/test-bootstrap-replicates.R
+++ b/tests/testthat/test-bootstrap-replicates.R
@@ -25,13 +25,13 @@ input <- tibble(
 # Initialize two test functions to run using bootstrap_replicates
 hhsize_by_sex <- function(
     data,
-    weight, # string name of weight column in `data`
+    wt_col, # string name of weight column in `data`
     hhsize # string name of hhsize column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
-      weighted_mean = sum(.data[[hhsize]] * .data[[weight]], na.rm = TRUE)/sum(.data[[weight]], na.rm = TRUE),
+      weighted_mean = sum(.data[[hhsize]] * .data[[wt_col]], na.rm = TRUE)/sum(.data[[wt_col]], na.rm = TRUE),
       .groups = "drop"
     )
   
@@ -40,13 +40,13 @@ hhsize_by_sex <- function(
 
 count_by_sex <- function(
     data,
-    weight # string name of weight column in `data`
+    wt_col # string name of weight column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
       count = n(),
-      weighted_count = sum(.data[[weight]]),
+      weighted_count = sum(.data[[wt_col]]),
       .groups = "drop"
     )
   
@@ -57,7 +57,7 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   output_hhsize <- bootstrap_replicates(
     data = input,
     f = hhsize_by_sex,
-    weight = "weight",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     hhsize = "hhsize",
     id_cols = "sex"
@@ -66,23 +66,23 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   # Compare results
   expect_equal(
     output_hhsize$main_estimate, 
-    hhsize_by_sex(input, weight = "weight", hhsize = "hhsize")
+    hhsize_by_sex(input, wt_col = "weight", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[1]], 
-    hhsize_by_sex(input, weight = "repwt1", hhsize = "hhsize")
+    hhsize_by_sex(input, wt_col = "repwt1", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[2]], 
-    hhsize_by_sex(input, weight = "repwt2", hhsize = "hhsize")
+    hhsize_by_sex(input, wt_col = "repwt2", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[3]], 
-    hhsize_by_sex(input, weight = "repwt3", hhsize = "hhsize")
+    hhsize_by_sex(input, wt_col = "repwt3", hhsize = "hhsize")
   )
   expect_equal(
     output_hhsize$replicate_estimates[[4]], 
-    hhsize_by_sex(input, weight = "repwt4", hhsize = "hhsize")
+    hhsize_by_sex(input, wt_col = "repwt4", hhsize = "hhsize")
   )
 })
 
@@ -90,7 +90,7 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   output_count <- bootstrap_replicates(
     data = input,
     f = count_by_sex,
-    weight = "weight",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     id_cols = "sex"
   )
@@ -98,22 +98,22 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   # Compare results for count_by_sex
   expect_equal(
     output_count$main_estimate, 
-    count_by_sex(input, weight = "weight")
+    count_by_sex(input, wt_col = "weight")
   )
   expect_equal(
     output_count$replicate_estimates[[1]], 
-    count_by_sex(input, weight = "repwt1")
+    count_by_sex(input, wt_col = "repwt1")
   )
   expect_equal(
     output_count$replicate_estimates[[2]], 
-    count_by_sex(input, weight = "repwt2")
+    count_by_sex(input, wt_col = "repwt2")
   )
   expect_equal(
     output_count$replicate_estimates[[3]], 
-    count_by_sex(input, weight = "repwt3")
+    count_by_sex(input, wt_col = "repwt3")
   )
   expect_equal(
     output_count$replicate_estimates[[4]], 
-    count_by_sex(input, weight = "repwt4")
+    count_by_sex(input, wt_col = "repwt4")
   )
 })

--- a/tests/testthat/test-bootstrap-replicates.R
+++ b/tests/testthat/test-bootstrap-replicates.R
@@ -57,7 +57,7 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   output_hhsize <- bootstrap_replicates(
     data = input,
     f = hhsize_by_sex,
-    wt_col = "weight",
+    weight = "weight",
     repwt_cols = paste0("repwt", 1:4),
     hhsize = "hhsize",
     id_cols = "sex"
@@ -90,7 +90,7 @@ test_that("bootstrap_replicates produces expected main and bootstrapped results 
   output_count <- bootstrap_replicates(
     data = input,
     f = count_by_sex,
-    wt_col = "weight",
+    weight = "weight",
     repwt_cols = paste0("repwt", 1:4),
     id_cols = "sex"
   )

--- a/tests/testthat/test-crosstab-count.R
+++ b/tests/testthat/test-crosstab-count.R
@@ -51,7 +51,7 @@ test_that("crosstab_count produces correct count results on database, with `ever
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = tbl(con, "input"),
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE 
   ) |> collect()
@@ -116,7 +116,7 @@ test_that("crosstab_count produces correct count results on database, with `ever
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = tbl(con, "input"),
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   ) |> collect()
@@ -177,7 +177,7 @@ test_that("crosstab_count produces correct count results on tibble, with `every_
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = input_tb,
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE
   )
@@ -231,7 +231,7 @@ test_that("crosstab_count produces correct count results on tibble, with `every_
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = input_tb,
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   ) 

--- a/tests/testthat/test-crosstab-count.R
+++ b/tests/testthat/test-crosstab-count.R
@@ -80,7 +80,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_count,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     id_cols = c("AGE_bucket", "RACE_ETH_bucket"),
@@ -145,7 +145,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_count,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     id_cols = c("AGE_bucket", "RACE_ETH_bucket"),
@@ -201,7 +201,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_count,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_count"),
@@ -255,7 +255,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_count,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     id_cols = c("AGE_bucket", "RACE_ETH_bucket"),

--- a/tests/testthat/test-crosstab-count.R
+++ b/tests/testthat/test-crosstab-count.R
@@ -51,7 +51,7 @@ test_that("crosstab_count produces correct count results on database, with `ever
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = tbl(con, "input"),
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE 
   ) |> collect()
@@ -80,7 +80,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_count,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     id_cols = c("AGE_bucket", "RACE_ETH_bucket"),
@@ -116,7 +116,7 @@ test_that("crosstab_count produces correct count results on database, with `ever
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = tbl(con, "input"),
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   ) |> collect()
@@ -145,7 +145,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_count,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     id_cols = c("AGE_bucket", "RACE_ETH_bucket"),
@@ -177,7 +177,7 @@ test_that("crosstab_count produces correct count results on tibble, with `every_
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = input_tb,
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE
   )
@@ -201,7 +201,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_count,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_count"),
@@ -231,7 +231,7 @@ test_that("crosstab_count produces correct count results on tibble, with `every_
   # Compute weighted and unweighted counts using DuckDB table
   output_tb <- crosstab_count(
     data = input_tb,
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   ) 
@@ -255,7 +255,7 @@ test_that("crosstab_count with estimate_with_boostrap_se produces correct count 
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_count,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     id_cols = c("AGE_bucket", "RACE_ETH_bucket"),

--- a/tests/testthat/test-crosstab-mean.R
+++ b/tests/testthat/test-crosstab-mean.R
@@ -62,7 +62,7 @@ test_that("crosstab_mean produces correct weighted mean results on database with
   output_tb <- crosstab_mean(
     data = tbl(con, "input"),
     value = "NUMPREC",
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   ) |> collect()
@@ -127,7 +127,7 @@ test_that("crosstab_mean produces correct weighted mean results on database with
   output_tb <- crosstab_mean(
     data = tbl(con, "input"),
     value = "NUMPREC",
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE
   ) |> collect()
@@ -188,7 +188,7 @@ test_that("crosstab_mean produces correct weighted mean results on tibble with e
   output_tb <- crosstab_mean(
     data = input_tb,
     value = "NUMPREC",
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   )
@@ -242,7 +242,7 @@ test_that("crosstab_mean produces correct weighted mean results on tibble with e
   output_tb <- crosstab_mean(
     data = input_tb,
     value = "NUMPREC",
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE
   )

--- a/tests/testthat/test-crosstab-mean.R
+++ b/tests/testthat/test-crosstab-mean.R
@@ -91,7 +91,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_mean,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),
@@ -156,7 +156,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_mean,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),
@@ -212,7 +212,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_mean,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),
@@ -266,7 +266,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_mean,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),

--- a/tests/testthat/test-crosstab-mean.R
+++ b/tests/testthat/test-crosstab-mean.R
@@ -62,7 +62,7 @@ test_that("crosstab_mean produces correct weighted mean results on database with
   output_tb <- crosstab_mean(
     data = tbl(con, "input"),
     value = "NUMPREC",
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   ) |> collect()
@@ -91,7 +91,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_mean,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),
@@ -127,7 +127,7 @@ test_that("crosstab_mean produces correct weighted mean results on database with
   output_tb <- crosstab_mean(
     data = tbl(con, "input"),
     value = "NUMPREC",
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE
   ) |> collect()
@@ -156,7 +156,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_mean,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),
@@ -188,7 +188,7 @@ test_that("crosstab_mean produces correct weighted mean results on tibble with e
   output_tb <- crosstab_mean(
     data = input_tb,
     value = "NUMPREC",
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = FALSE
   )
@@ -212,7 +212,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_mean,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),
@@ -242,7 +242,7 @@ test_that("crosstab_mean produces correct weighted mean results on tibble with e
   output_tb <- crosstab_mean(
     data = input_tb,
     value = "NUMPREC",
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("HHINCOME_bucket", "AGE_bucket", "RACE_ETH_bucket"),
     every_combo = TRUE
   )
@@ -266,7 +266,7 @@ test_that("crosstab_mean with estimate_with_boostrap_se produces correct results
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_mean,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("weighted_mean"),

--- a/tests/testthat/test-crosstab-percent.R
+++ b/tests/testthat/test-crosstab-percent.R
@@ -60,7 +60,7 @@ test_that("crosstab_percent produces correct percent results on database with ev
   # Compute percentages using DuckDB table
   output_tb <- crosstab_percent(
     data = tbl(con, "input"),
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("AGE_bucket")
   ) |> collect()
@@ -89,7 +89,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_percent,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),
@@ -125,7 +125,7 @@ test_that("crosstab_percent produces correct percent results on database with ev
   # Compute percentages using DuckDB table
   output_tb <- crosstab_percent(
     data = tbl(con, "input"),
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("AGE_bucket"),
     every_combo = TRUE
@@ -156,7 +156,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_percent,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),
@@ -192,7 +192,7 @@ test_that("crosstab_percent produces correct percent results on database with ev
   # Compute percentages using DuckDB table
   output_tb <- crosstab_percent(
     data = tbl(con, "input"),
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("RACE_ETH_bucket")
   ) |> collect()
@@ -221,7 +221,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_percent,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),
@@ -253,7 +253,7 @@ test_that("crosstab_percent produces correct percent results on tibble with ever
   # Compute percentages on tibble input
   output_tb <- crosstab_percent(
     data = input_tb,
-    weight = "PERWT",
+    wt_col = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("RACE_ETH_bucket")
   )
@@ -277,7 +277,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_percent,
-    weight = "PERWT",
+    wt_col = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),

--- a/tests/testthat/test-crosstab-percent.R
+++ b/tests/testthat/test-crosstab-percent.R
@@ -89,7 +89,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_percent,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),
@@ -156,7 +156,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_percent,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),
@@ -221,7 +221,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = tbl(con, "input"),
     f = crosstab_percent,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),
@@ -277,7 +277,7 @@ test_that("crosstab_percent with estimate_with_boostrap_se produces correct perc
   output_tb <- estimate_with_bootstrap_se(
     data = input_tb,
     f = crosstab_percent,
-    wt_col = "PERWT",
+    weight = "PERWT",
     repwt_cols = paste0("REPWTP", sprintf("%d", 1:4)),
     constant = 4/80,
     se_cols = c("percent"),

--- a/tests/testthat/test-crosstab-percent.R
+++ b/tests/testthat/test-crosstab-percent.R
@@ -60,7 +60,7 @@ test_that("crosstab_percent produces correct percent results on database with ev
   # Compute percentages using DuckDB table
   output_tb <- crosstab_percent(
     data = tbl(con, "input"),
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("AGE_bucket")
   ) |> collect()
@@ -125,7 +125,7 @@ test_that("crosstab_percent produces correct percent results on database with ev
   # Compute percentages using DuckDB table
   output_tb <- crosstab_percent(
     data = tbl(con, "input"),
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("AGE_bucket"),
     every_combo = TRUE
@@ -192,7 +192,7 @@ test_that("crosstab_percent produces correct percent results on database with ev
   # Compute percentages using DuckDB table
   output_tb <- crosstab_percent(
     data = tbl(con, "input"),
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("RACE_ETH_bucket")
   ) |> collect()
@@ -253,7 +253,7 @@ test_that("crosstab_percent produces correct percent results on tibble with ever
   # Compute percentages on tibble input
   output_tb <- crosstab_percent(
     data = input_tb,
-    wt = "PERWT",
+    weight = "PERWT",
     group_by = c("AGE_bucket", "RACE_ETH_bucket"),
     percent_group_by = c("RACE_ETH_bucket")
   )

--- a/tests/testthat/test-estimate-with-bootstrap-se.R
+++ b/tests/testthat/test-estimate-with-bootstrap-se.R
@@ -25,13 +25,13 @@ input_data <- tibble(
 # Define the functions
 hhsize_by_sex <- function(
     data,
-    weight,      # String name of weight column in `data`
+    wt_col,      # String name of weight column in `data`
     hhsize   # String name of hhsize column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
-      weighted_mean = sum(.data[[hhsize]] * .data[[weight]], na.rm = TRUE) / sum(.data[[weight]], na.rm = TRUE),
+      weighted_mean = sum(.data[[hhsize]] * .data[[wt_col]], na.rm = TRUE) / sum(.data[[wt_col]], na.rm = TRUE),
       .groups = "drop"
     )
   return(result)
@@ -39,13 +39,13 @@ hhsize_by_sex <- function(
 
 count_by_sex <- function(
     data,
-    weight    # String name of weight column in `data`
+    wt_col    # String name of weight column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
       count = n(),
-      weighted_count = sum(.data[[weight]], na.rm = TRUE),
+      weighted_count = sum(.data[[wt_col]], na.rm = TRUE),
       .groups = "drop"
     )
   return(result)
@@ -71,7 +71,7 @@ test_that("estimate_with_bootstrap_se produces correct results for hhsize_by_sex
   output_hhsize <- estimate_with_bootstrap_se(
     data = input_data,
     f = hhsize_by_sex,
-    weight = "weight",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_mean"),
@@ -86,7 +86,7 @@ test_that("estimate_with_bootstrap_se produces correct results for count_by_sex"
   output_count <- estimate_with_bootstrap_se(
     data = input_data,
     f = count_by_sex,
-    weight = "weight",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_count", "count"),
@@ -100,7 +100,7 @@ test_that("estimate_with_bootstrap_se produces correct results for crosstab_coun
   output_count <- estimate_with_bootstrap_se(
     data = input_data,
     f = crosstab_count,
-    weight = "weight",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_count", "count"),

--- a/tests/testthat/test-estimate-with-bootstrap-se.R
+++ b/tests/testthat/test-estimate-with-bootstrap-se.R
@@ -71,7 +71,7 @@ test_that("estimate_with_bootstrap_se produces correct results for hhsize_by_sex
   output_hhsize <- estimate_with_bootstrap_se(
     data = input_data,
     f = hhsize_by_sex,
-    wt_col = "weight",
+    weight = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_mean"),
@@ -86,7 +86,7 @@ test_that("estimate_with_bootstrap_se produces correct results for count_by_sex"
   output_count <- estimate_with_bootstrap_se(
     data = input_data,
     f = count_by_sex,
-    wt_col = "weight",
+    weight = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_count", "count"),
@@ -100,7 +100,7 @@ test_that("estimate_with_bootstrap_se produces correct results for crosstab_coun
   output_count <- estimate_with_bootstrap_se(
     data = input_data,
     f = crosstab_count,
-    wt_col = "weight",
+    weight = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_count", "count"),

--- a/tests/testthat/test-estimate-with-bootstrap-se.R
+++ b/tests/testthat/test-estimate-with-bootstrap-se.R
@@ -15,7 +15,7 @@ input_data <- tibble(
   per_id = c(1, 2, 3, 4, 5),
   sex = c(1, 0, 1, 1, 0),
   hhsize = c(2, 3, 2, 1, 1),
-  wt = c(10, 12, 15, 30, 20),
+  weight = c(10, 12, 15, 30, 20),
   repwt1 = c(11, 13, 16, 28, 22),
   repwt2 = c(8, 8, 16, 25, 22),
   repwt3 = c(2, 4, 10, 14, 13),
@@ -25,13 +25,13 @@ input_data <- tibble(
 # Define the functions
 hhsize_by_sex <- function(
     data,
-    wt,      # String name of weight column in `data`
+    weight,      # String name of weight column in `data`
     hhsize   # String name of hhsize column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
-      weighted_mean = sum(.data[[hhsize]] * .data[[wt]], na.rm = TRUE) / sum(.data[[wt]], na.rm = TRUE),
+      weighted_mean = sum(.data[[hhsize]] * .data[[weight]], na.rm = TRUE) / sum(.data[[weight]], na.rm = TRUE),
       .groups = "drop"
     )
   return(result)
@@ -39,13 +39,13 @@ hhsize_by_sex <- function(
 
 count_by_sex <- function(
     data,
-    wt    # String name of weight column in `data`
+    weight    # String name of weight column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
       count = n(),
-      weighted_count = sum(.data[[wt]], na.rm = TRUE),
+      weighted_count = sum(.data[[weight]], na.rm = TRUE),
       .groups = "drop"
     )
   return(result)
@@ -71,7 +71,7 @@ test_that("estimate_with_bootstrap_se produces correct results for hhsize_by_sex
   output_hhsize <- estimate_with_bootstrap_se(
     data = input_data,
     f = hhsize_by_sex,
-    wt_col = "wt",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_mean"),
@@ -86,7 +86,7 @@ test_that("estimate_with_bootstrap_se produces correct results for count_by_sex"
   output_count <- estimate_with_bootstrap_se(
     data = input_data,
     f = count_by_sex,
-    wt_col = "wt",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_count", "count"),
@@ -100,7 +100,7 @@ test_that("estimate_with_bootstrap_se produces correct results for crosstab_coun
   output_count <- estimate_with_bootstrap_se(
     data = input_data,
     f = crosstab_count,
-    wt_col = "wt",
+    wt_col = "weight",
     repwt_cols = paste0("repwt", 1:4),
     constant = 1,   # Using constant = 1 for simplicity
     se_cols = c("weighted_count", "count"),

--- a/tests/testthat/test-se-from-bootstrap.R
+++ b/tests/testthat/test-se-from-bootstrap.R
@@ -15,7 +15,7 @@ input_data <- tibble(
   per_id = c(1, 2, 3, 4, 5),
   sex = c(1, 0, 1, 1, 0),
   hhsize = c(2, 3, 2, 1, 1),
-  wt = c(10, 12, 15, 30, 20),
+  weight = c(10, 12, 15, 30, 20),
   repwt1 = c(11, 13, 16, 28, 22),
   repwt2 = c(8, 8, 16, 25, 22),
   repwt3 = c(2, 4, 10, 14, 13),
@@ -25,13 +25,13 @@ input_data <- tibble(
 # Initialize two test functions
 hhsize_by_sex <- function(
     data,
-    wt, # string name of weight column in `data`
+    weight, # string name of weight column in `data`
     hhsize # string name of hhsize column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
-      weighted_mean = sum(.data[[hhsize]] * .data[[wt]], na.rm = TRUE)/sum(.data[[wt]], na.rm = TRUE),
+      weighted_mean = sum(.data[[hhsize]] * .data[[weight]], na.rm = TRUE)/sum(.data[[weight]], na.rm = TRUE),
       .groups = "drop"
     )
   
@@ -40,13 +40,13 @@ hhsize_by_sex <- function(
 
 count_by_sex <- function(
     data,
-    wt # string name of weight column in `data`
+    weight # string name of weight column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
       count = n(),
-      weighted_count = sum(.data[[wt]]),
+      weighted_count = sum(.data[[weight]]),
       .groups = "drop"
     )
   
@@ -57,7 +57,7 @@ count_by_sex <- function(
 input_bootstrap_count <- bootstrap_replicates(
   data = input_data,
   f = count_by_sex,
-  wt_col = "wt",
+  wt_col = "weight",
   repwt_cols = paste0("repwt", 1:4),
   id_cols = "sex"
 )
@@ -65,7 +65,7 @@ input_bootstrap_count <- bootstrap_replicates(
 input_bootstrap_hhsize <- bootstrap_replicates(
   data = input_data,
   f = hhsize_by_sex,
-  wt_col = "wt",
+  wt_col = "weight",
   repwt_cols = paste0("repwt", 1:4),
   hhsize = "hhsize",
   id_cols = "sex"

--- a/tests/testthat/test-se-from-bootstrap.R
+++ b/tests/testthat/test-se-from-bootstrap.R
@@ -25,13 +25,13 @@ input_data <- tibble(
 # Initialize two test functions
 hhsize_by_sex <- function(
     data,
-    weight, # string name of weight column in `data`
-    hhsize # string name of hhsize column in `data`
+    wt_col, # string name of weight column in `data`
+    hhsize_col # string name of hhsize column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
-      weighted_mean = sum(.data[[hhsize]] * .data[[weight]], na.rm = TRUE)/sum(.data[[weight]], na.rm = TRUE),
+      weighted_mean = sum(.data[[hhsize_col]] * .data[[wt_col]], na.rm = TRUE)/sum(.data[[wt_col]], na.rm = TRUE),
       .groups = "drop"
     )
   
@@ -40,13 +40,13 @@ hhsize_by_sex <- function(
 
 count_by_sex <- function(
     data,
-    weight # string name of weight column in `data`
+    wt_col # string name of weight column in `data`
 ) {
   result <- data |>
     group_by(sex) |>
     summarize(
       count = n(),
-      weighted_count = sum(.data[[weight]]),
+      weighted_count = sum(.data[[wt_col]]),
       .groups = "drop"
     )
   
@@ -57,7 +57,7 @@ count_by_sex <- function(
 input_bootstrap_count <- bootstrap_replicates(
   data = input_data,
   f = count_by_sex,
-  weight = "weight",
+  wt_col = "weight",
   repwt_cols = paste0("repwt", 1:4),
   id_cols = "sex"
 )
@@ -65,9 +65,9 @@ input_bootstrap_count <- bootstrap_replicates(
 input_bootstrap_hhsize <- bootstrap_replicates(
   data = input_data,
   f = hhsize_by_sex,
-  weight = "weight",
+  wt_col = "weight",
   repwt_cols = paste0("repwt", 1:4),
-  hhsize = "hhsize",
+  hhsize_col = "hhsize",
   id_cols = "sex"
 )
 

--- a/tests/testthat/test-se-from-bootstrap.R
+++ b/tests/testthat/test-se-from-bootstrap.R
@@ -57,7 +57,7 @@ count_by_sex <- function(
 input_bootstrap_count <- bootstrap_replicates(
   data = input_data,
   f = count_by_sex,
-  wt_col = "weight",
+  weight = "weight",
   repwt_cols = paste0("repwt", 1:4),
   id_cols = "sex"
 )
@@ -65,7 +65,7 @@ input_bootstrap_count <- bootstrap_replicates(
 input_bootstrap_hhsize <- bootstrap_replicates(
   data = input_data,
   f = hhsize_by_sex,
-  wt_col = "weight",
+  weight = "weight",
   repwt_cols = paste0("repwt", 1:4),
   hhsize = "hhsize",
   id_cols = "sex"


### PR DESCRIPTION
Analogous arguments in different functions all follow a standardized naming convention, and I've updated the README with a brief explanation.